### PR TITLE
Implement payment listing and cash flow logic

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 
 from app.api.v1.endpoints import auth, users, organizations, dashboard, finance
-from app.api.v1.endpoints import inventory, crm, hr
+from app.api.v1.endpoints import inventory, crm, hr, roles, tenants
 
 # Create main API router
 api_router = APIRouter()
@@ -10,6 +10,8 @@ api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["Authentication"])
 api_router.include_router(users.router, prefix="/users", tags=["Users"])
 api_router.include_router(organizations.router, prefix="/organizations", tags=["Organizations"])
+api_router.include_router(roles.router, prefix="/roles", tags=["Roles"])
+api_router.include_router(tenants.router, prefix="/tenants", tags=["Tenants"])
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["Dashboard"])
 
 # ERP module routers

--- a/backend/app/api/v1/endpoints/crm.py
+++ b/backend/app/api/v1/endpoints/crm.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from fastapi import APIRouter, Depends, HTTPException, status, Query
+from fastapi import APIRouter, Depends, HTTPException, status, Query, Response
 from sqlalchemy.orm import Session
 
 from ....core.database import get_db
@@ -9,7 +9,8 @@ from ....services.crm_service import CRMService
 from ....schemas.crm import (
     CustomerCreate, CustomerUpdate, CustomerResponse, CustomerList,
     LeadCreate, LeadUpdate, LeadResponse, LeadList,
-    OpportunityCreate, OpportunityUpdate, OpportunityResponse, OpportunityList
+    OpportunityCreate, OpportunityUpdate, OpportunityResponse, OpportunityList,
+    CommunicationCreate, CommunicationResponse, CommunicationList, OpportunityPipeline
 )
 
 router = APIRouter()
@@ -38,6 +39,13 @@ async def update_customer(customer_id: int, payload: CustomerUpdate, db: Session
     return customer
 
 
+@router.delete('/customers/{customer_id}', status_code=status.HTTP_204_NO_CONTENT)
+async def delete_customer(customer_id: int, db: Session = Depends(get_db), current_user: User = Depends(require_permission('crm:customer:delete'))):
+    if not CRMService(db).delete_customer(customer_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Customer not found')
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
 # Leads
 @router.post('/leads', response_model=LeadResponse, status_code=status.HTTP_201_CREATED)
 async def create_lead(payload: LeadCreate, db: Session = Depends(get_db), current_user: User = Depends(require_permission('crm:lead:create'))):
@@ -61,6 +69,13 @@ async def update_lead(lead_id: int, payload: LeadUpdate, db: Session = Depends(g
     return lead
 
 
+@router.delete('/leads/{lead_id}', status_code=status.HTTP_204_NO_CONTENT)
+async def delete_lead(lead_id: int, db: Session = Depends(get_db), current_user: User = Depends(require_permission('crm:lead:delete'))):
+    if not CRMService(db).delete_lead(lead_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Lead not found')
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
 # Opportunities
 @router.post('/opportunities', response_model=OpportunityResponse, status_code=status.HTTP_201_CREATED)
 async def create_opportunity(payload: OpportunityCreate, db: Session = Depends(get_db), current_user: User = Depends(require_permission('crm:opportunity:create'))):
@@ -82,5 +97,48 @@ async def update_opportunity(opp_id: int, payload: OpportunityUpdate, db: Sessio
     if not opp:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Opportunity not found')
     return opp
+
+
+@router.delete('/opportunities/{opp_id}', status_code=status.HTTP_204_NO_CONTENT)
+async def delete_opportunity(opp_id: int, db: Session = Depends(get_db), current_user: User = Depends(require_permission('crm:opportunity:delete'))):
+    if not CRMService(db).delete_opportunity(opp_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Opportunity not found')
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post('/opportunities/{opp_id}/advance', response_model=OpportunityResponse)
+async def advance_opportunity(opp_id: int, db: Session = Depends(get_db), current_user: User = Depends(require_permission('crm:opportunity:update'))):
+    svc = CRMService(db)
+    opp = svc.advance_opportunity(opp_id)
+    if not opp:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Opportunity not found')
+    return opp
+
+
+@router.get('/opportunities/pipeline', response_model=OpportunityPipeline)
+async def opportunity_pipeline(db: Session = Depends(get_db), current_user: User = Depends(require_permission('crm:opportunity:read'))):
+    return CRMService(db).get_opportunity_pipeline()
+
+
+# Communications
+@router.post('/communications', response_model=CommunicationResponse, status_code=status.HTTP_201_CREATED)
+async def create_communication(payload: CommunicationCreate, db: Session = Depends(get_db), current_user: User = Depends(require_permission('crm:communication:create'))):
+    return CRMService(db).create_communication(payload)
+
+
+@router.get('/communications', response_model=CommunicationList)
+async def list_communications(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(10, ge=1, le=100),
+    customer_id: Optional[int] = Query(None),
+    lead_id: Optional[int] = Query(None),
+    opportunity_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_permission('crm:communication:read')),
+):
+    svc = CRMService(db)
+    comms = svc.list_communications(skip=skip, limit=limit, customer_id=customer_id, lead_id=lead_id, opportunity_id=opportunity_id)
+    total = svc.count_communications(customer_id=customer_id, lead_id=lead_id, opportunity_id=opportunity_id)
+    return CommunicationList(communications=comms, total=total, page=skip // limit + 1, size=limit)
 
 

--- a/backend/app/api/v1/endpoints/finance.py
+++ b/backend/app/api/v1/endpoints/finance.py
@@ -355,20 +355,24 @@ async def process_payment(
 async def get_payments(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
+    sort_by: Optional[str] = Query(None),
+    sort_dir: Optional[str] = Query("desc"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_permission("finance:payment:read"))
 ):
     """Get payments"""
     finance_service = FinanceService(db)
-    # This would need to be implemented in the service
-    payments = []  # Placeholder
-    total = 0
-    
+    payments, total = finance_service.get_payments(
+        skip=skip,
+        limit=limit,
+        sort_by=sort_by,
+        sort_dir=sort_dir,
+    )
     return PaymentList(
         payments=payments,
         total=total,
         page=skip // limit + 1,
-        size=limit
+        size=limit,
     )
 
 # Financial Reporting Endpoints

--- a/backend/app/api/v1/endpoints/hr.py
+++ b/backend/app/api/v1/endpoints/hr.py
@@ -7,8 +7,19 @@ from ....core.security import require_permission
 from ....models.user import User
 from ....services.hr_service import HRService
 from ....schemas.hr import (
-    EmployeeCreate, EmployeeUpdate, EmployeeResponse, EmployeeList,
-    AttendanceCreate, AttendanceResponse, AttendanceList
+    EmployeeCreate,
+    EmployeeUpdate,
+    EmployeeResponse,
+    EmployeeList,
+    AttendanceCreate,
+    AttendanceResponse,
+    AttendanceList,
+    PayrollCreate,
+    PayrollResponse,
+    PayrollList,
+    LeaveCreate,
+    LeaveResponse,
+    LeaveList,
 )
 
 router = APIRouter()
@@ -47,5 +58,31 @@ async def list_attendance(employee_id: Optional[int] = Query(None), skip: int = 
     records = svc.list_attendance(employee_id=employee_id, skip=skip, limit=limit)
     total = svc.count_attendance(employee_id=employee_id)
     return AttendanceList(records=records, total=total, page=skip // limit + 1, size=limit)
+
+
+@router.post('/payrolls', response_model=PayrollResponse, status_code=status.HTTP_201_CREATED)
+async def create_payroll(payload: PayrollCreate, db: Session = Depends(get_db), current_user: User = Depends(require_permission('hr:payroll:create'))):
+    return HRService(db).create_payroll(payload)
+
+
+@router.get('/payrolls', response_model=PayrollList)
+async def list_payrolls(employee_id: Optional[int] = Query(None), skip: int = Query(0, ge=0), limit: int = Query(10, ge=1, le=100), db: Session = Depends(get_db), current_user: User = Depends(require_permission('hr:payroll:read'))):
+    svc = HRService(db)
+    records = svc.list_payrolls(employee_id=employee_id, skip=skip, limit=limit)
+    total = svc.count_payrolls(employee_id=employee_id)
+    return PayrollList(records=records, total=total, page=skip // limit + 1, size=limit)
+
+
+@router.post('/leaves', response_model=LeaveResponse, status_code=status.HTTP_201_CREATED)
+async def create_leave(payload: LeaveCreate, db: Session = Depends(get_db), current_user: User = Depends(require_permission('hr:leave:create'))):
+    return HRService(db).create_leave(payload)
+
+
+@router.get('/leaves', response_model=LeaveList)
+async def list_leaves(employee_id: Optional[int] = Query(None), skip: int = Query(0, ge=0), limit: int = Query(10, ge=1, le=100), db: Session = Depends(get_db), current_user: User = Depends(require_permission('hr:leave:read'))):
+    svc = HRService(db)
+    records = svc.list_leaves(employee_id=employee_id, skip=skip, limit=limit)
+    total = svc.count_leaves(employee_id=employee_id)
+    return LeaveList(records=records, total=total, page=skip // limit + 1, size=limit)
 
 

--- a/backend/app/api/v1/endpoints/roles.py
+++ b/backend/app/api/v1/endpoints/roles.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.core.database import get_db
+from app.core.security import require_permission
+from app.models.role import Role
+from app.models.user import User
+
+router = APIRouter()
+
+
+@router.get("/", response_model=List[dict])
+async def get_roles(
+    current_user: User = Depends(require_permission("read:role")),
+    db: Session = Depends(get_db),
+):
+    """Get all roles"""
+    roles = db.query(Role).all()
+    return [role.to_dict() for role in roles]
+
+
+@router.post("/", response_model=dict)
+async def create_role(
+    role_data: dict,
+    current_user: User = Depends(require_permission("create:role")),
+    db: Session = Depends(get_db),
+):
+    """Create new role"""
+    role = Role(**role_data)
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+    return role.to_dict()
+
+
+@router.put("/{role_id}", response_model=dict)
+async def update_role(
+    role_id: int,
+    role_data: dict,
+    current_user: User = Depends(require_permission("update:role")),
+    db: Session = Depends(get_db),
+):
+    """Update role"""
+    role = db.query(Role).filter(Role.id == role_id).first()
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Role not found",
+        )
+    for field, value in role_data.items():
+        if hasattr(role, field) and field not in ["id", "created_at", "updated_at"]:
+            setattr(role, field, value)
+    db.commit()
+    db.refresh(role)
+    return role.to_dict()
+
+
+@router.delete("/{role_id}")
+async def delete_role(
+    role_id: int,
+    current_user: User = Depends(require_permission("delete:role")),
+    db: Session = Depends(get_db),
+):
+    """Delete role"""
+    role = db.query(Role).filter(Role.id == role_id).first()
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Role not found",
+        )
+    db.delete(role)
+    db.commit()
+    return {"message": "Role deleted successfully"}

--- a/backend/app/api/v1/endpoints/tenants.py
+++ b/backend/app/api/v1/endpoints/tenants.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.core.database import get_db
+from app.core.security import require_permission
+from app.models.tenant import Tenant
+from app.models.user import User
+
+router = APIRouter()
+
+
+@router.get("/", response_model=List[dict])
+async def get_tenants(
+    current_user: User = Depends(require_permission("read:tenant")),
+    db: Session = Depends(get_db),
+):
+    """Get all tenants"""
+    tenants = db.query(Tenant).all()
+    return [tenant.to_dict() for tenant in tenants]
+
+
+@router.post("/", response_model=dict)
+async def create_tenant(
+    tenant_data: dict,
+    current_user: User = Depends(require_permission("create:tenant")),
+    db: Session = Depends(get_db),
+):
+    """Create new tenant"""
+    tenant = Tenant(**tenant_data)
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant.to_dict()
+
+
+@router.put("/{tenant_id}", response_model=dict)
+async def update_tenant(
+    tenant_id: int,
+    tenant_data: dict,
+    current_user: User = Depends(require_permission("update:tenant")),
+    db: Session = Depends(get_db),
+):
+    """Update tenant"""
+    tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+    if not tenant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+    for field, value in tenant_data.items():
+        if hasattr(tenant, field) and field not in ["id", "created_at", "updated_at"]:
+            setattr(tenant, field, value)
+    db.commit()
+    db.refresh(tenant)
+    return tenant.to_dict()
+
+
+@router.delete("/{tenant_id}")
+async def delete_tenant(
+    tenant_id: int,
+    current_user: User = Depends(require_permission("delete:tenant")),
+    db: Session = Depends(get_db),
+):
+    """Delete tenant"""
+    tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+    if not tenant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+    db.delete(tenant)
+    db.commit()
+    return {"message": "Tenant deleted successfully"}

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -35,6 +35,20 @@ async def get_user(
     return user.to_dict()
 
 
+@router.post("/", response_model=dict)
+async def create_user(
+    user_data: dict,
+    current_user: User = Depends(require_permission("create:user")),
+    db: Session = Depends(get_db),
+):
+    """Create new user"""
+    user = User(**user_data)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user.to_dict()
+
+
 @router.put("/{user_id}", response_model=dict)
 async def update_user(
     user_id: int,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -21,7 +21,7 @@ from .inventory import (
 	InventoryValuationLayer,
 )
 from .crm import Customer, Lead, Opportunity
-from .hr import Employee, Attendance
+from .hr import Employee, Attendance, Payroll, Leave
 from .audit import AuditLog
 
 __all__ = [
@@ -61,5 +61,7 @@ __all__ = [
     "Opportunity",
     "Employee",
     "Attendance",
+    "Payroll",
+    "Leave",
     "AuditLog"
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -20,7 +20,7 @@ from .inventory import (
 	Shipment, ShipmentLine,
 	InventoryValuationLayer,
 )
-from .crm import Customer, Lead, Opportunity
+from .crm import Customer, Lead, Opportunity, LeadStatus, OpportunityStage, Communication, CommunicationType
 from .hr import Employee, Attendance, Payroll, Leave
 from .audit import AuditLog
 
@@ -59,6 +59,10 @@ __all__ = [
     "Customer",
     "Lead",
     "Opportunity",
+    "LeadStatus",
+    "OpportunityStage",
+    "Communication",
+    "CommunicationType",
     "Employee",
     "Attendance",
     "Payroll",

--- a/backend/app/models/crm.py
+++ b/backend/app/models/crm.py
@@ -21,6 +21,13 @@ class OpportunityStage(str, enum.Enum):
     LOST = "lost"
 
 
+class CommunicationType(str, enum.Enum):
+    CALL = "call"
+    EMAIL = "email"
+    MEETING = "meeting"
+    NOTE = "note"
+
+
 class Customer(BaseModel, Base):
     __tablename__ = "customers"
 
@@ -60,5 +67,21 @@ class Opportunity(BaseModel, Base):
     notes = Column(Text, nullable=True)
 
     customer = relationship("Customer", back_populates="opportunities")
+
+
+class Communication(BaseModel, Base):
+    __tablename__ = "communications"
+
+    customer_id = Column(Integer, ForeignKey("customers.id"), nullable=True)
+    lead_id = Column(Integer, ForeignKey("leads.id"), nullable=True)
+    opportunity_id = Column(Integer, ForeignKey("opportunities.id"), nullable=True)
+    type = Column(Enum(CommunicationType), nullable=False)
+    subject = Column(String(200), nullable=True)
+    content = Column(Text, nullable=True)
+    occurred_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    customer = relationship("Customer")
+    lead = relationship("Lead")
+    opportunity = relationship("Opportunity")
 
 

--- a/backend/app/models/hr.py
+++ b/backend/app/models/hr.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey, Numeric, Enum
+from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, ForeignKey, Numeric, Enum, Date
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 import enum
@@ -21,6 +21,9 @@ class Employee(BaseModel, Base):
     department = Column(String(100), nullable=True)
     title = Column(String(100), nullable=True)
     status = Column(Enum(EmploymentStatus), nullable=False, default=EmploymentStatus.ACTIVE)
+    attendance_records = relationship("Attendance", back_populates="employee")
+    payrolls = relationship("Payroll", back_populates="employee")
+    leaves = relationship("Leave", back_populates="employee")
 
 
 class Attendance(BaseModel, Base):
@@ -31,5 +34,49 @@ class Attendance(BaseModel, Base):
     check_in = Column(DateTime, nullable=True)
     check_out = Column(DateTime, nullable=True)
     notes = Column(Text, nullable=True)
+    employee = relationship("Employee", back_populates="attendance_records")
+
+
+class PayrollStatus(str, enum.Enum):
+    PENDING = "pending"
+    PAID = "paid"
+
+
+class Payroll(BaseModel, Base):
+    __tablename__ = "payrolls"
+
+    employee_id = Column(Integer, ForeignKey("employees.id"), nullable=False)
+    period_start = Column(Date, nullable=False)
+    period_end = Column(Date, nullable=False)
+    base_salary = Column(Numeric(12, 2), nullable=False)
+    allowances = Column(Numeric(12, 2), nullable=False, default=0)
+    deductions = Column(Numeric(12, 2), nullable=False, default=0)
+    net_pay = Column(Numeric(12, 2), nullable=False)
+    status = Column(Enum(PayrollStatus), nullable=False, default=PayrollStatus.PENDING)
+    employee = relationship("Employee", back_populates="payrolls")
+
+
+class LeaveType(str, enum.Enum):
+    SICK = "sick"
+    VACATION = "vacation"
+    UNPAID = "unpaid"
+
+
+class LeaveStatus(str, enum.Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class Leave(BaseModel, Base):
+    __tablename__ = "leaves"
+
+    employee_id = Column(Integer, ForeignKey("employees.id"), nullable=False)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=False)
+    type = Column(Enum(LeaveType), nullable=False)
+    status = Column(Enum(LeaveStatus), nullable=False, default=LeaveStatus.PENDING)
+    reason = Column(Text, nullable=True)
+    employee = relationship("Employee", back_populates="leaves")
 
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Boolean, Integer, ForeignKey, Text
+from sqlalchemy import Column, String, Boolean, Integer, ForeignKey, Text, DateTime
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from datetime import datetime

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -17,7 +17,9 @@ from .crm import (
 )
 from .hr import (
     EmployeeCreate, EmployeeUpdate, EmployeeResponse, EmployeeList,
-    AttendanceCreate, AttendanceResponse, AttendanceList
+    AttendanceCreate, AttendanceResponse, AttendanceList,
+    PayrollCreate, PayrollResponse, PayrollList,
+    LeaveCreate, LeaveResponse, LeaveList
 )
 from .inventory import (
     ProductCreate, ProductUpdate, ProductResponse, ProductList,
@@ -80,5 +82,11 @@ __all__ = [
     "PaymentList",
     "FinancialSummary",
     "CashFlowSummary",
-    "FinancialMetrics"
+    "FinancialMetrics",
+    "PayrollCreate",
+    "PayrollResponse",
+    "PayrollList",
+    "LeaveCreate",
+    "LeaveResponse",
+    "LeaveList",
 ]

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -13,7 +13,8 @@ from .finance import (
 from .crm import (
     CustomerCreate, CustomerUpdate, CustomerResponse, CustomerList,
     LeadCreate, LeadUpdate, LeadResponse, LeadList,
-    OpportunityCreate, OpportunityUpdate, OpportunityResponse, OpportunityList
+    OpportunityCreate, OpportunityUpdate, OpportunityResponse, OpportunityList,
+    CommunicationCreate, CommunicationResponse, CommunicationList, OpportunityPipeline
 )
 from .hr import (
     EmployeeCreate, EmployeeUpdate, EmployeeResponse, EmployeeList,
@@ -44,6 +45,22 @@ __all__ = [
     "OrganizationResponse",
     "PaginationParams",
     "PaginatedResponse",
+    "CustomerCreate",
+    "CustomerUpdate",
+    "CustomerResponse",
+    "CustomerList",
+    "LeadCreate",
+    "LeadUpdate",
+    "LeadResponse",
+    "LeadList",
+    "OpportunityCreate",
+    "OpportunityUpdate",
+    "OpportunityResponse",
+    "OpportunityList",
+    "CommunicationCreate",
+    "CommunicationResponse",
+    "CommunicationList",
+    "OpportunityPipeline",
     "ProductCreate",
     "ProductUpdate",
     "ProductResponse",

--- a/backend/app/schemas/crm.py
+++ b/backend/app/schemas/crm.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Dict
 from decimal import Decimal
 from datetime import datetime
 from pydantic import BaseModel, Field
@@ -118,5 +118,38 @@ class OpportunityList(BaseModel):
     total: int
     page: int
     size: int
+
+
+class CommunicationBase(BaseModel):
+    customer_id: Optional[int] = None
+    lead_id: Optional[int] = None
+    opportunity_id: Optional[int] = None
+    type: str = Field(..., max_length=20)
+    subject: Optional[str] = Field(None, max_length=200)
+    content: Optional[str] = Field(None, max_length=2000)
+    occurred_at: Optional[datetime] = None
+
+
+class CommunicationCreate(CommunicationBase):
+    pass
+
+
+class CommunicationResponse(CommunicationBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class CommunicationList(BaseModel):
+    communications: List[CommunicationResponse]
+    total: int
+    page: int
+    size: int
+
+
+OpportunityPipeline = Dict[str, List[OpportunityResponse]]
 
 

--- a/backend/app/schemas/hr.py
+++ b/backend/app/schemas/hr.py
@@ -1,5 +1,5 @@
 from typing import Optional, List
-from datetime import datetime
+from datetime import datetime, date
 from pydantic import BaseModel, Field
 
 
@@ -61,6 +61,58 @@ class AttendanceResponse(AttendanceCreate):
 
 class AttendanceList(BaseModel):
     records: List[AttendanceResponse]
+    total: int
+    page: int
+    size: int
+
+
+class PayrollCreate(BaseModel):
+    employee_id: int
+    period_start: date
+    period_end: date
+    base_salary: float
+    allowances: Optional[float] = 0
+    deductions: Optional[float] = 0
+    net_pay: Optional[float] = None
+    status: Optional[str] = Field('pending')
+
+
+class PayrollResponse(PayrollCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class PayrollList(BaseModel):
+    records: List[PayrollResponse]
+    total: int
+    page: int
+    size: int
+
+
+class LeaveCreate(BaseModel):
+    employee_id: int
+    start_date: date
+    end_date: date
+    type: str
+    status: Optional[str] = Field('pending')
+    reason: Optional[str] = Field(None, max_length=1000)
+
+
+class LeaveResponse(LeaveCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class LeaveList(BaseModel):
+    records: List[LeaveResponse]
     total: int
     page: int
     size: int

--- a/backend/app/services/crm_service.py
+++ b/backend/app/services/crm_service.py
@@ -1,12 +1,13 @@
-from typing import List, Optional
+from typing import List, Optional, Dict
 from sqlalchemy.orm import Session
 from sqlalchemy import desc
 
-from ..models.crm import Customer, Lead, Opportunity
+from ..models.crm import Customer, Lead, Opportunity, OpportunityStage, Communication
 from ..schemas.crm import (
     CustomerCreate, CustomerUpdate,
     LeadCreate, LeadUpdate,
-    OpportunityCreate, OpportunityUpdate
+    OpportunityCreate, OpportunityUpdate,
+    CommunicationCreate
 )
 from ..core.exceptions import ValidationError
 
@@ -47,6 +48,14 @@ class CRMService:
             query = query.filter((Customer.name.ilike(like)) | (Customer.email.ilike(like)))
         return query.count()
 
+    def delete_customer(self, customer_id: int) -> bool:
+        customer = self.db.query(Customer).filter(Customer.id == customer_id).first()
+        if not customer:
+            return False
+        self.db.delete(customer)
+        self.db.commit()
+        return True
+
     # Leads
     def create_lead(self, data: LeadCreate) -> Lead:
         lead = Lead(**data.dict())
@@ -78,6 +87,14 @@ class CRMService:
             like = f"%{q}%"
             query = query.filter((Lead.name.ilike(like)) | (Lead.email.ilike(like)) | (Lead.phone.ilike(like)))
         return query.count()
+
+    def delete_lead(self, lead_id: int) -> bool:
+        lead = self.db.query(Lead).filter(Lead.id == lead_id).first()
+        if not lead:
+            return False
+        self.db.delete(lead)
+        self.db.commit()
+        return True
 
     # Opportunities
     def create_opportunity(self, data: OpportunityCreate) -> Opportunity:
@@ -111,4 +128,71 @@ class CRMService:
             query = query.filter(Opportunity.name.ilike(like))
         return query.count()
 
+    def delete_opportunity(self, opp_id: int) -> bool:
+        opp = self.db.query(Opportunity).filter(Opportunity.id == opp_id).first()
+        if not opp:
+            return False
+        self.db.delete(opp)
+        self.db.commit()
+        return True
 
+    def advance_opportunity(self, opp_id: int) -> Optional[Opportunity]:
+        opp = self.db.query(Opportunity).filter(Opportunity.id == opp_id).first()
+        if not opp:
+            return None
+        stages = list(OpportunityStage)
+        try:
+            idx = stages.index(opp.stage)
+            if idx < len(stages) - 1:
+                opp.stage = stages[idx + 1]
+                self.db.commit()
+                self.db.refresh(opp)
+        except ValueError:
+            pass
+        return opp
+
+    def get_opportunity_pipeline(self) -> Dict[str, List[Opportunity]]:
+        pipeline = {stage.value: [] for stage in OpportunityStage}
+        for opp in self.db.query(Opportunity).all():
+            pipeline[opp.stage.value].append(opp)
+        return pipeline
+
+    # Communications
+    def create_communication(self, data: CommunicationCreate) -> Communication:
+        comm = Communication(**data.dict())
+        self.db.add(comm)
+        self.db.commit()
+        self.db.refresh(comm)
+        return comm
+
+    def list_communications(
+        self,
+        skip: int = 0,
+        limit: int = 10,
+        customer_id: Optional[int] = None,
+        lead_id: Optional[int] = None,
+        opportunity_id: Optional[int] = None,
+    ) -> List[Communication]:
+        query = self.db.query(Communication)
+        if customer_id:
+            query = query.filter(Communication.customer_id == customer_id)
+        if lead_id:
+            query = query.filter(Communication.lead_id == lead_id)
+        if opportunity_id:
+            query = query.filter(Communication.opportunity_id == opportunity_id)
+        return query.order_by(desc(Communication.occurred_at)).offset(skip).limit(limit).all()
+
+    def count_communications(
+        self,
+        customer_id: Optional[int] = None,
+        lead_id: Optional[int] = None,
+        opportunity_id: Optional[int] = None,
+    ) -> int:
+        query = self.db.query(Communication)
+        if customer_id:
+            query = query.filter(Communication.customer_id == customer_id)
+        if lead_id:
+            query = query.filter(Communication.lead_id == lead_id)
+        if opportunity_id:
+            query = query.filter(Communication.opportunity_id == opportunity_id)
+        return query.count()

--- a/backend/app/services/finance_service.py
+++ b/backend/app/services/finance_service.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 from decimal import Decimal
 from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
@@ -17,6 +17,7 @@ from ..models.finance import (
     InvoiceType,
     InvoiceLineItem,
     AccountingPeriod,
+    AccountCategory,
 )
 from ..models.inventory import Product, Shipment, ShipmentLine
 from ..schemas.finance import (
@@ -542,6 +543,37 @@ class FinanceService:
         return row
     
     # Payment Management
+    def get_payments(
+        self,
+        skip: int = 0,
+        limit: int = 100,
+        sort_by: Optional[str] = None,
+        sort_dir: Optional[str] = None,
+        **filters,
+    ) -> Tuple[List[Payment], int]:
+        """Get payments with optional filtering"""
+        query = self.db.query(Payment)
+
+        if filters.get("invoice_id"):
+            query = query.filter(Payment.invoice_id == filters["invoice_id"])
+        if filters.get("status"):
+            query = query.filter(Payment.status == filters["status"])
+
+        colmap = {
+            "payment_date": Payment.payment_date,
+            "amount": Payment.amount,
+            "created_at": Payment.created_at,
+        }
+        col = colmap.get(sort_by or "payment_date")
+        if sort_dir == "asc":
+            query = query.order_by(col.asc())
+        else:
+            query = query.order_by(col.desc())
+
+        total = query.count()
+        payments = query.offset(skip).limit(limit).all()
+        return payments, total
+
     def create_payment(self, payment_data: PaymentCreate) -> Payment:
         """Create a new payment"""
         try:
@@ -578,26 +610,7 @@ class FinanceService:
         self.db.commit()
         self.db.refresh(payment)
         return payment
-    
-    def process_payment(self, payment_id: int) -> Payment:
-        """Process a payment and create corresponding transaction"""
-        payment = self.db.query(Payment).filter(Payment.id == payment_id).first()
-        if not payment:
-            raise ValidationError("Payment not found")
-        
-        if payment.status == "completed":
-            raise BusinessLogicError("Payment is already completed")
-        
-        # Create transaction for the payment
-        # Debit: Cash/Bank account, Credit: Accounts Receivable
-        # This is a simplified version - in practice, you'd need to determine the cash account
-        
-        # For now, just mark as completed
-        payment.status = "completed"
-        self.db.commit()
-        self.db.refresh(payment)
-        return payment
-    
+
     # Financial Reporting
     def get_financial_summary(self) -> FinancialSummary:
         """Get overall financial summary"""
@@ -646,13 +659,50 @@ class FinanceService:
     
     def get_cash_flow_summary(self, period: str = "month") -> CashFlowSummary:
         """Get cash flow summary for a period"""
-        # This is a simplified version - in practice, you'd calculate from transactions
+        now = datetime.now()
+        if period == "day":
+            start = datetime(now.year, now.month, now.day)
+        elif period == "week":
+            start = datetime(now.year, now.month, now.day) - timedelta(days=now.weekday())
+        elif period == "month":
+            start = datetime(now.year, now.month, 1)
+        elif period == "quarter":
+            q_month = (now.month - 1) // 3 * 3 + 1
+            start = datetime(now.year, q_month, 1)
+        elif period == "year":
+            start = datetime(now.year, 1, 1)
+        else:
+            raise ValidationError("Invalid period")
+
+        cash_accounts = self.db.query(Account).filter(
+            and_(
+                Account.account_type == AccountType.ASSET,
+                Account.category == AccountCategory.CURRENT_ASSETS,
+            )
+        ).all()
+        cash_balance = sum(acc.current_balance for acc in cash_accounts)
+
+        txns = (
+            self.db.query(Transaction)
+            .filter(
+                Transaction.transaction_date >= start,
+                Transaction.transaction_type.in_(
+                    [TransactionType.RECEIPT, TransactionType.PAYMENT]
+                ),
+            )
+            .all()
+        )
+        cash_in = sum(t.amount for t in txns if t.transaction_type == TransactionType.RECEIPT)
+        cash_out = sum(t.amount for t in txns if t.transaction_type == TransactionType.PAYMENT)
+        opening_balance = cash_balance - (cash_in - cash_out)
+        closing_balance = cash_balance
+
         return CashFlowSummary(
             period=period,
-            opening_balance=Decimal('0.00'),
-            cash_in=Decimal('0.00'),
-            cash_out=Decimal('0.00'),
-            closing_balance=Decimal('0.00')
+            opening_balance=opening_balance,
+            cash_in=cash_in,
+            cash_out=cash_out,
+            closing_balance=closing_balance,
         )
     
     def get_financial_metrics(self) -> FinancialMetrics:

--- a/backend/app/services/hr_service.py
+++ b/backend/app/services/hr_service.py
@@ -3,8 +3,14 @@ from sqlalchemy.orm import Session
 from sqlalchemy import desc
 from datetime import datetime
 
-from ..models.hr import Employee, Attendance
-from ..schemas.hr import EmployeeCreate, EmployeeUpdate, AttendanceCreate
+from ..models.hr import Employee, Attendance, Payroll, Leave
+from ..schemas.hr import (
+    EmployeeCreate,
+    EmployeeUpdate,
+    AttendanceCreate,
+    PayrollCreate,
+    LeaveCreate,
+)
 
 
 class HRService:
@@ -61,6 +67,49 @@ class HRService:
         query = self.db.query(Attendance)
         if employee_id:
             query = query.filter(Attendance.employee_id == employee_id)
+        return query.count()
+
+    # Payroll
+    def create_payroll(self, data: PayrollCreate) -> Payroll:
+        payload = data.dict()
+        if payload.get("net_pay") is None:
+            payload["net_pay"] = payload.get("base_salary", 0) + payload.get("allowances", 0) - payload.get("deductions", 0)
+        payroll = Payroll(**payload)
+        self.db.add(payroll)
+        self.db.commit()
+        self.db.refresh(payroll)
+        return payroll
+
+    def list_payrolls(self, employee_id: Optional[int] = None, skip: int = 0, limit: int = 10) -> List[Payroll]:
+        query = self.db.query(Payroll)
+        if employee_id:
+            query = query.filter(Payroll.employee_id == employee_id)
+        return query.order_by(desc(Payroll.period_start)).offset(skip).limit(limit).all()
+
+    def count_payrolls(self, employee_id: Optional[int] = None) -> int:
+        query = self.db.query(Payroll)
+        if employee_id:
+            query = query.filter(Payroll.employee_id == employee_id)
+        return query.count()
+
+    # Leave
+    def create_leave(self, data: LeaveCreate) -> Leave:
+        leave = Leave(**data.dict())
+        self.db.add(leave)
+        self.db.commit()
+        self.db.refresh(leave)
+        return leave
+
+    def list_leaves(self, employee_id: Optional[int] = None, skip: int = 0, limit: int = 10) -> List[Leave]:
+        query = self.db.query(Leave)
+        if employee_id:
+            query = query.filter(Leave.employee_id == employee_id)
+        return query.order_by(desc(Leave.start_date)).offset(skip).limit(limit).all()
+
+    def count_leaves(self, employee_id: Optional[int] = None) -> int:
+        query = self.db.query(Leave)
+        if employee_id:
+            query = query.filter(Leave.employee_id == employee_id)
         return query.count()
 
 

--- a/frontend/src/pages/CRM.tsx
+++ b/frontend/src/pages/CRM.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import { crmService } from '../services/crmService'
-import { Plus } from 'lucide-react'
+import { Plus, Trash, ArrowRight } from 'lucide-react'
 import { useTableState } from '../hooks/useTableState'
 import toast from 'react-hot-toast'
 
 const CRM: React.FC = () => {
-  const [tab, setTab] = useState<'customers'|'leads'|'opportunities'>('customers')
+  const [tab, setTab] = useState<'customers'|'leads'|'opportunities'|'pipeline'|'communications'>('customers')
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="bg-white shadow-sm border-b">
@@ -17,7 +17,7 @@ const CRM: React.FC = () => {
       <div className="bg-white border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <nav className="flex space-x-8">
-            {['customers','leads','opportunities'].map(id => (
+            {['customers','leads','opportunities','pipeline','communications'].map(id => (
               <button key={id} onClick={()=>setTab(id as any)}
                 className={`py-4 px-1 border-b-2 font-medium text-sm ${tab===id?'border-blue-500 text-blue-600':'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
               >{id[0].toUpperCase()+id.slice(1)}</button>
@@ -29,6 +29,8 @@ const CRM: React.FC = () => {
         {tab==='customers' && <CustomersSection />}
         {tab==='leads' && <LeadsSection />}
         {tab==='opportunities' && <OpportunitiesSection />}
+        {tab==='pipeline' && <PipelineSection />}
+        {tab==='communications' && <CommunicationsSection />}
       </div>
     </div>
   )
@@ -41,6 +43,7 @@ function CustomersSection(){
   const load = async()=>{ try { const r = await crmService.getCustomers({ q, skip: (page-1)*size, limit: size }); setItems(r.customers||[]) } catch(e:any){ toast.error('Load failed') } }
   useEffect(()=>{ load() }, [q, page, size])
   const create = async()=>{ try { await crmService.createCustomer(form); setForm({name:'',email:'',phone:''}); toast.success('Added'); load() } catch(e:any){ toast.error('Create failed') } }
+  const remove = async(id:number)=>{ try { await crmService.deleteCustomer(id); toast.success('Deleted'); load() } catch(e:any){ toast.error('Delete failed') } }
   return (
     <div className="bg-white rounded-lg shadow p-6">
       <div className="flex justify-between mb-4">
@@ -54,10 +57,15 @@ function CustomersSection(){
       </div>
       <div className="overflow-x-auto">
         <table className="min-w-full text-sm">
-          <thead className="bg-gray-50"><tr><th className="px-3 py-2 text-left">Name</th><th className="px-3 py-2 text-left">Email</th><th className="px-3 py-2 text-left">Phone</th></tr></thead>
+          <thead className="bg-gray-50"><tr><th className="px-3 py-2 text-left">Name</th><th className="px-3 py-2 text-left">Email</th><th className="px-3 py-2 text-left">Phone</th><th></th></tr></thead>
           <tbody>
             {items.map((c:any)=> (
-              <tr key={c.id} className="border-t"><td className="px-3 py-2">{c.name}</td><td className="px-3 py-2">{c.email}</td><td className="px-3 py-2">{c.phone}</td></tr>
+              <tr key={c.id} className="border-t">
+                <td className="px-3 py-2">{c.name}</td>
+                <td className="px-3 py-2">{c.email}</td>
+                <td className="px-3 py-2">{c.phone}</td>
+                <td className="px-3 py-2 text-right"><button onClick={()=>remove(c.id)} className="text-red-600"><Trash className="w-4 h-4" /></button></td>
+              </tr>
             ))}
           </tbody>
         </table>
@@ -73,6 +81,7 @@ function LeadsSection(){
   const load = async()=>{ try { const r = await crmService.getLeads({ q, skip: (page-1)*size, limit: size }); setItems(r.leads||[]) } catch(e:any){ toast.error('Load failed') } }
   useEffect(()=>{ load() }, [q, page, size])
   const create = async()=>{ try { await crmService.createLead(form as any); setForm({name:'',email:'',phone:'',source:''}); toast.success('Added'); load() } catch(e:any){ toast.error('Create failed') } }
+  const remove = async(id:number)=>{ try { await crmService.deleteLead(id); toast.success('Deleted'); load() } catch(e:any){ toast.error('Delete failed') } }
   return (
     <div className="bg-white rounded-lg shadow p-6">
       <div className="flex justify-between mb-4">
@@ -87,10 +96,17 @@ function LeadsSection(){
       </div>
       <div className="overflow-x-auto">
         <table className="min-w-full text-sm">
-          <thead className="bg-gray-50"><tr><th className="px-3 py-2 text-left">Name</th><th className="px-3 py-2 text-left">Email</th><th className="px-3 py-2 text-left">Phone</th><th className="px-3 py-2 text-left">Source</th><th className="px-3 py-2 text-left">Status</th></tr></thead>
+          <thead className="bg-gray-50"><tr><th className="px-3 py-2 text-left">Name</th><th className="px-3 py-2 text-left">Email</th><th className="px-3 py-2 text-left">Phone</th><th className="px-3 py-2 text-left">Source</th><th className="px-3 py-2 text-left">Status</th><th></th></tr></thead>
           <tbody>
             {items.map((l:any)=> (
-              <tr key={l.id} className="border-t"><td className="px-3 py-2">{l.name}</td><td className="px-3 py-2">{l.email}</td><td className="px-3 py-2">{l.phone}</td><td className="px-3 py-2">{l.source}</td><td className="px-3 py-2">{l.status}</td></tr>
+              <tr key={l.id} className="border-t">
+                <td className="px-3 py-2">{l.name}</td>
+                <td className="px-3 py-2">{l.email}</td>
+                <td className="px-3 py-2">{l.phone}</td>
+                <td className="px-3 py-2">{l.source}</td>
+                <td className="px-3 py-2">{l.status}</td>
+                <td className="px-3 py-2 text-right"><button onClick={()=>remove(l.id)} className="text-red-600"><Trash className="w-4 h-4" /></button></td>
+              </tr>
             ))}
           </tbody>
         </table>
@@ -106,6 +122,8 @@ function OpportunitiesSection(){
   const load = async()=>{ try { const r = await crmService.getOpportunities({ q, skip: (page-1)*size, limit: size }); setItems(r.opportunities||[]) } catch(e:any){ toast.error('Load failed') } }
   useEffect(()=>{ load() }, [q, page, size])
   const create = async()=>{ try { await crmService.createOpportunity(form as any); setForm({name:'',value:0,stage:'prospecting'}); toast.success('Added'); load() } catch(e:any){ toast.error('Create failed') } }
+  const remove = async(id:number)=>{ try { await crmService.deleteOpportunity(id); toast.success('Deleted'); load() } catch(e:any){ toast.error('Delete failed') } }
+  const advance = async(id:number)=>{ try { await crmService.advanceOpportunity(id); toast.success('Advanced'); load() } catch(e:any){ toast.error('Advance failed') } }
   return (
     <div className="bg-white rounded-lg shadow p-6">
       <div className="flex justify-between mb-4">
@@ -121,10 +139,84 @@ function OpportunitiesSection(){
       </div>
       <div className="overflow-x-auto">
         <table className="min-w-full text-sm">
-          <thead className="bg-gray-50"><tr><th className="px-3 py-2 text-left">Name</th><th className="px-3 py-2 text-left">Value</th><th className="px-3 py-2 text-left">Stage</th></tr></thead>
+          <thead className="bg-gray-50"><tr><th className="px-3 py-2 text-left">Name</th><th className="px-3 py-2 text-left">Value</th><th className="px-3 py-2 text-left">Stage</th><th></th></tr></thead>
           <tbody>
             {items.map((o:any)=> (
-              <tr key={o.id} className="border-t"><td className="px-3 py-2">{o.name}</td><td className="px-3 py-2">{o.value}</td><td className="px-3 py-2">{o.stage}</td></tr>
+              <tr key={o.id} className="border-t">
+                <td className="px-3 py-2">{o.name}</td>
+                <td className="px-3 py-2">{o.value}</td>
+                <td className="px-3 py-2 capitalize">{o.stage}</td>
+                <td className="px-3 py-2 text-right flex gap-2 justify-end">
+                  <button onClick={()=>advance(o.id)} className="text-blue-600"><ArrowRight className="w-4 h-4" /></button>
+                  <button onClick={()=>remove(o.id)} className="text-red-600"><Trash className="w-4 h-4" /></button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function PipelineSection(){
+  const [pipeline, setPipeline] = useState<any>({})
+  const load = async()=>{ try { const r = await crmService.getOpportunityPipeline(); setPipeline(r) } catch(e:any){ toast.error('Load failed') } }
+  useEffect(()=>{ load() }, [])
+  const advance = async(id:number)=>{ try { await crmService.advanceOpportunity(id); load() } catch(e:any){ toast.error('Advance failed') } }
+  const stages = ['prospecting','qualification','proposal','negotiation','won','lost']
+  return (
+    <div className="flex gap-4 overflow-x-auto">
+      {stages.map(s=> (
+        <div key={s} className="bg-white rounded-lg shadow p-4 min-w-[200px] flex-1">
+          <h3 className="font-semibold mb-2 capitalize">{s}</h3>
+          {(pipeline[s]||[]).map((o:any)=>(
+            <div key={o.id} className="border rounded p-2 mb-2 flex justify-between items-center">
+              <span>{o.name}</span>
+              {s!=='won' && s!=='lost' && <button onClick={()=>advance(o.id)} className="text-xs text-blue-600">Next</button>}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function CommunicationsSection(){
+  const [items, setItems] = useState<any[]>([])
+  const [form, setForm] = useState({ type:'call', subject:'', content:'', lead_id:'', opportunity_id:'' })
+  const { page, size } = useTableState({ size: 20 })
+  const load = async()=>{ try { const r = await crmService.getCommunications({ skip:(page-1)*size, limit:size }); setItems(r.communications||[]) } catch(e:any){ toast.error('Load failed') } }
+  useEffect(()=>{ load() }, [page, size])
+  const create = async()=>{
+    try {
+      const payload:any = { type: form.type, subject: form.subject, content: form.content }
+      if(form.lead_id) payload.lead_id = Number(form.lead_id)
+      if(form.opportunity_id) payload.opportunity_id = Number(form.opportunity_id)
+      await crmService.createCommunication(payload)
+      setForm({ type:'call', subject:'', content:'', lead_id:'', opportunity_id:'' })
+      toast.success('Logged')
+      load()
+    } catch(e:any){ toast.error('Create failed') }
+  }
+  return (
+    <div className="bg-white rounded-lg shadow p-6">
+      <div className="flex gap-2 mb-4">
+        <select className="input" value={form.type} onChange={e=>setForm({...form,type:e.target.value})}>
+          {['call','email','meeting','note'].map(t=> <option key={t} value={t}>{t}</option>)}
+        </select>
+        <input className="input" placeholder="Subject" value={form.subject} onChange={e=>setForm({...form,subject:e.target.value})} />
+        <input className="input flex-1" placeholder="Content" value={form.content} onChange={e=>setForm({...form,content:e.target.value})} />
+        <input className="input w-24" placeholder="Lead ID" value={form.lead_id} onChange={e=>setForm({...form,lead_id:e.target.value})} />
+        <input className="input w-24" placeholder="Opp ID" value={form.opportunity_id} onChange={e=>setForm({...form,opportunity_id:e.target.value})} />
+        <button className="btn-primary" onClick={create}><Plus className="w-4 h-4 mr-2" /> Log</button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50"><tr><th className="px-3 py-2 text-left">Type</th><th className="px-3 py-2 text-left">Subject</th><th className="px-3 py-2 text-left">Content</th><th className="px-3 py-2 text-left">Date</th></tr></thead>
+          <tbody>
+            {items.map((c:any)=> (
+              <tr key={c.id} className="border-t"><td className="px-3 py-2 capitalize">{c.type}</td><td className="px-3 py-2">{c.subject}</td><td className="px-3 py-2">{c.content}</td><td className="px-3 py-2">{new Date(c.occurred_at).toLocaleDateString()}</td></tr>
             ))}
           </tbody>
         </table>

--- a/frontend/src/pages/Finance.tsx
+++ b/frontend/src/pages/Finance.tsx
@@ -1,343 +1,213 @@
-import React, { useState } from 'react';
-import { 
-  DollarSign, 
-  TrendingUp, 
-  TrendingDown, 
-  CreditCard, 
-  FileText, 
-  BarChart3,
-  Plus,
-  Eye,
-  Download
-} from 'lucide-react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
+import React, { useEffect, useState } from 'react';
+import {
+  financeService,
+  Account,
+  Transaction,
+  Invoice,
+  Payment,
+  FinancialSummary,
+  CashFlowSummary,
+  FinancialMetrics,
+} from '../services/financeService';
+
+const tabs = ['overview', 'accounts', 'transactions', 'invoices', 'payments', 'reports'] as const;
+
+type Tab = typeof tabs[number];
 
 const Finance: React.FC = () => {
-  const [activeTab, setActiveTab] = useState('overview');
+  const [activeTab, setActiveTab] = useState<Tab>('overview');
+  const [summary, setSummary] = useState<FinancialSummary | null>(null);
+  const [cashFlow, setCashFlow] = useState<CashFlowSummary | null>(null);
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [metrics, setMetrics] = useState<FinancialMetrics | null>(null);
 
-  // Mock data for charts
-  const cashFlowData = [
-    { month: 'Jan', cashIn: 45000, cashOut: 32000 },
-    { month: 'Feb', cashIn: 52000, cashOut: 38000 },
-    { month: 'Mar', cashIn: 48000, cashOut: 35000 },
-    { month: 'Apr', cashIn: 61000, cashOut: 42000 },
-    { month: 'May', cashIn: 55000, cashOut: 39000 },
-    { month: 'Jun', cashIn: 67000, cashOut: 45000 },
-  ];
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        if (activeTab === 'overview') {
+          const [sum, flow] = await Promise.all([
+            financeService.getFinancialSummary(),
+            financeService.getCashFlowSummary(),
+          ]);
+          setSummary(sum);
+          setCashFlow(flow);
+        } else if (activeTab === 'accounts') {
+          const res = await financeService.getAccounts();
+          setAccounts(res.accounts);
+        } else if (activeTab === 'transactions') {
+          const res = await financeService.getTransactions();
+          setTransactions(res.transactions);
+        } else if (activeTab === 'invoices') {
+          const res = await financeService.getInvoices();
+          setInvoices(res.invoices);
+        } else if (activeTab === 'payments') {
+          const res = await financeService.getPayments();
+          setPayments(res.payments);
+        } else if (activeTab === 'reports') {
+          const m = await financeService.getFinancialMetrics();
+          setMetrics(m);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    loadData();
+  }, [activeTab]);
 
-  const accountDistribution = [
-    { name: 'Assets', value: 65, color: '#10B981' },
-    { name: 'Liabilities', value: 20, color: '#EF4444' },
-    { name: 'Equity', value: 15, color: '#3B82F6' },
-  ];
-
-  const recentTransactions = [
-    { id: 1, description: 'Client Payment - Project Alpha', amount: 15000, type: 'credit', date: '2024-01-15' },
-    { id: 2, description: 'Office Supplies', amount: 250, type: 'debit', date: '2024-01-14' },
-    { id: 3, description: 'Software License Renewal', amount: 1200, type: 'debit', date: '2024-01-13' },
-    { id: 4, description: 'Consulting Fee', amount: 8000, type: 'credit', date: '2024-01-12' },
-  ];
-
-  const upcomingInvoices = [
-    { id: 1, customer: 'TechCorp Inc.', amount: 25000, dueDate: '2024-01-25', status: 'pending' },
-    { id: 2, customer: 'Global Solutions', amount: 18000, dueDate: '2024-01-28', status: 'pending' },
-    { id: 3, customer: 'Innovation Labs', amount: 32000, dueDate: '2024-01-30', status: 'pending' },
-  ];
-
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-    }).format(amount);
-  };
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'pending': return 'bg-yellow-100 text-yellow-800';
-      case 'paid': return 'bg-green-100 text-green-800';
-      case 'overdue': return 'bg-red-100 text-red-800';
-      default: return 'bg-gray-100 text-gray-800';
-    }
-  };
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center py-6">
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900">Finance Dashboard</h1>
-              <p className="text-gray-600">Manage your financial operations and track performance</p>
-            </div>
-            <div className="flex space-x-3">
-              <button className="btn-primary">
-                <Plus className="w-4 h-4 mr-2" />
-                New Transaction
-              </button>
-              <button className="btn-secondary">
-                <Download className="w-4 h-4 mr-2" />
-                Export Report
-              </button>
-            </div>
-          </div>
-        </div>
+    <div className="p-4">
+      <div className="mb-4 space-x-2">
+        {tabs.map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-3 py-1 rounded ${activeTab === tab ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+          >
+            {tab.charAt(0).toUpperCase() + tab.slice(1)}
+          </button>
+        ))}
       </div>
 
-      {/* Navigation Tabs */}
-      <div className="bg-white border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <nav className="flex space-x-8">
-            {[
-              { id: 'overview', label: 'Overview', icon: BarChart3 },
-              { id: 'accounts', label: 'Chart of Accounts', icon: CreditCard },
-              { id: 'transactions', label: 'Transactions', icon: TrendingUp },
-              { id: 'invoices', label: 'Invoices', icon: FileText },
-              { id: 'reports', label: 'Reports', icon: Download },
-            ].map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={`py-4 px-1 border-b-2 font-medium text-sm ${
-                  activeTab === tab.id
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                }`}
-              >
-                <tab.icon className="w-4 h-4 inline mr-2" />
-                {tab.label}
-              </button>
+      {activeTab === 'overview' && summary && cashFlow && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="p-4 border rounded">
+              <h3 className="font-semibold">Total Assets</h3>
+              <p>{formatCurrency(summary.total_assets)}</p>
+            </div>
+            <div className="p-4 border rounded">
+              <h3 className="font-semibold">Total Liabilities</h3>
+              <p>{formatCurrency(summary.total_liabilities)}</p>
+            </div>
+            <div className="p-4 border rounded">
+              <h3 className="font-semibold">Total Equity</h3>
+              <p>{formatCurrency(summary.total_equity)}</p>
+            </div>
+            <div className="p-4 border rounded">
+              <h3 className="font-semibold">Net Income</h3>
+              <p>{formatCurrency(summary.net_income)}</p>
+            </div>
+          </div>
+          <div className="p-4 border rounded">
+            <h3 className="font-semibold mb-2">Cash Flow ({cashFlow.period})</h3>
+            <p>Opening: {formatCurrency(cashFlow.opening_balance)}</p>
+            <p>Cash In: {formatCurrency(cashFlow.cash_in)}</p>
+            <p>Cash Out: {formatCurrency(cashFlow.cash_out)}</p>
+            <p>Closing: {formatCurrency(cashFlow.closing_balance)}</p>
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'accounts' && (
+        <table className="min-w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 text-left">Code</th>
+              <th className="p-2 text-left">Name</th>
+              <th className="p-2 text-right">Balance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {accounts.map((acc) => (
+              <tr key={acc.id} className="border-t">
+                <td className="p-2">{acc.code}</td>
+                <td className="p-2">{acc.name}</td>
+                <td className="p-2 text-right">{formatCurrency(acc.current_balance)}</td>
+              </tr>
             ))}
-          </nav>
+          </tbody>
+        </table>
+      )}
+
+      {activeTab === 'transactions' && (
+        <table className="min-w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 text-left">Number</th>
+              <th className="p-2 text-left">Type</th>
+              <th className="p-2 text-right">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.map((txn) => (
+              <tr key={txn.id} className="border-t">
+                <td className="p-2">{txn.transaction_number}</td>
+                <td className="p-2">{txn.transaction_type}</td>
+                <td className="p-2 text-right">{formatCurrency(txn.amount)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {activeTab === 'invoices' && (
+        <table className="min-w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 text-left">Number</th>
+              <th className="p-2 text-left">Customer</th>
+              <th className="p-2 text-right">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {invoices.map((inv) => (
+              <tr key={inv.id} className="border-t">
+                <td className="p-2">{inv.invoice_number}</td>
+                <td className="p-2">{inv.customer_name}</td>
+                <td className="p-2 text-right">{formatCurrency(inv.total_amount)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {activeTab === 'payments' && (
+        <table className="min-w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 text-left">Number</th>
+              <th className="p-2 text-left">Method</th>
+              <th className="p-2 text-right">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {payments.map((pay) => (
+              <tr key={pay.id} className="border-t">
+                <td className="p-2">{pay.payment_number}</td>
+                <td className="p-2">{pay.payment_method}</td>
+                <td className="p-2 text-right">{formatCurrency(pay.amount)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {activeTab === 'reports' && metrics && (
+        <div className="grid grid-cols-2 gap-4">
+          <div className="p-4 border rounded">
+            <h3 className="font-semibold">Current Ratio</h3>
+            <p>{metrics.current_ratio.toFixed(2)}</p>
+          </div>
+          <div className="p-4 border rounded">
+            <h3 className="font-semibold">Debt to Equity</h3>
+            <p>{metrics.debt_to_equity.toFixed(2)}</p>
+          </div>
+          <div className="p-4 border rounded">
+            <h3 className="font-semibold">Profit Margin</h3>
+            <p>{metrics.profit_margin.toFixed(2)}</p>
+          </div>
+          <div className="p-4 border rounded">
+            <h3 className="font-semibold">Return on Equity</h3>
+            <p>{metrics.return_on_equity.toFixed(2)}</p>
+          </div>
         </div>
-      </div>
-
-      {/* Main Content */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {activeTab === 'overview' && (
-          <div className="space-y-8">
-            {/* Key Metrics */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-              <div className="bg-white rounded-lg shadow p-6">
-                <div className="flex items-center">
-                  <div className="p-2 bg-green-100 rounded-lg">
-                    <DollarSign className="w-6 h-6 text-green-600" />
-                  </div>
-                  <div className="ml-4">
-                    <p className="text-sm font-medium text-gray-600">Total Revenue</p>
-                    <p className="text-2xl font-bold text-gray-900">{formatCurrency(125000)}</p>
-                  </div>
-                </div>
-                <div className="mt-4 flex items-center text-sm">
-                  <TrendingUp className="w-4 h-4 text-green-500 mr-1" />
-                  <span className="text-green-600">+12.5%</span>
-                  <span className="text-gray-500 ml-1">from last month</span>
-                </div>
-              </div>
-
-              <div className="bg-white rounded-lg shadow p-6">
-                <div className="flex items-center">
-                  <div className="p-2 bg-red-100 rounded-lg">
-                    <TrendingDown className="w-6 h-6 text-red-600" />
-                  </div>
-                  <div className="ml-4">
-                    <p className="text-sm font-medium text-gray-600">Total Expenses</p>
-                    <p className="text-2xl font-bold text-gray-900">{formatCurrency(89000)}</p>
-                  </div>
-                </div>
-                <div className="mt-4 flex items-center text-sm">
-                  <TrendingDown className="w-4 h-4 text-red-500 mr-1" />
-                  <span className="text-red-600">+8.2%</span>
-                  <span className="text-gray-500 ml-1">from last month</span>
-                </div>
-              </div>
-
-              <div className="bg-white rounded-lg shadow p-6">
-                <div className="flex items-center">
-                  <div className="p-2 bg-blue-100 rounded-lg">
-                    <CreditCard className="w-6 h-6 text-blue-600" />
-                  </div>
-                  <div className="ml-4">
-                    <p className="text-sm font-medium text-gray-600">Cash Balance</p>
-                    <p className="text-2xl font-bold text-gray-900">{formatCurrency(36000)}</p>
-                  </div>
-                </div>
-                <div className="mt-4 flex items-center text-sm">
-                  <TrendingUp className="w-4 h-4 text-green-500 mr-1" />
-                  <span className="text-green-600">+5.8%</span>
-                  <span className="text-gray-500 ml-1">from last month</span>
-                </div>
-              </div>
-
-              <div className="bg-white rounded-lg shadow p-6">
-                <div className="flex items-center">
-                  <div className="p-2 bg-purple-100 rounded-lg">
-                    <FileText className="w-6 h-6 text-purple-600" />
-                  </div>
-                  <div className="ml-4">
-                    <p className="text-sm font-medium text-gray-600">Outstanding Invoices</p>
-                    <p className="text-2xl font-bold text-gray-900">{formatCurrency(75000)}</p>
-                  </div>
-                </div>
-                <div className="mt-4 flex items-center text-sm">
-                  <TrendingDown className="w-4 h-4 text-red-500 mr-1" />
-                  <span className="text-red-600">+2.1%</span>
-                  <span className="text-gray-500 ml-1">from last month</span>
-                </div>
-              </div>
-            </div>
-
-            {/* Charts Row */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-              {/* Cash Flow Chart */}
-              <div className="bg-white rounded-lg shadow p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Cash Flow Trend</h3>
-                <ResponsiveContainer width="100%" height={300}>
-                  <LineChart data={cashFlowData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="month" />
-                    <YAxis />
-                    <Tooltip formatter={(value) => formatCurrency(Number(value))} />
-                    <Line type="monotone" dataKey="cashIn" stroke="#10B981" strokeWidth={2} name="Cash In" />
-                    <Line type="monotone" dataKey="cashOut" stroke="#EF4444" strokeWidth={2} name="Cash Out" />
-                  </LineChart>
-                </ResponsiveContainer>
-              </div>
-
-              {/* Account Distribution */}
-              <div className="bg-white rounded-lg shadow p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Account Distribution</h3>
-                <ResponsiveContainer width="100%" height={300}>
-                  <PieChart>
-                    <Pie
-                      data={accountDistribution}
-                      cx="50%"
-                      cy="50%"
-                      outerRadius={80}
-                      fill="#8884d8"
-                      dataKey="value"
-                      label={({ name, value }) => `${name}: ${value}%`}
-                    >
-                      {accountDistribution.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                  </PieChart>
-                </ResponsiveContainer>
-              </div>
-            </div>
-
-            {/* Recent Activity Row */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-              {/* Recent Transactions */}
-              <div className="bg-white rounded-lg shadow p-6">
-                <div className="flex justify-between items-center mb-4">
-                  <h3 className="text-lg font-semibold text-gray-900">Recent Transactions</h3>
-                  <button className="text-blue-600 hover:text-blue-800 text-sm font-medium">View All</button>
-                </div>
-                <div className="space-y-3">
-                  {recentTransactions.map((transaction) => (
-                    <div key={transaction.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                      <div className="flex items-center">
-                        <div className={`w-2 h-2 rounded-full mr-3 ${
-                          transaction.type === 'credit' ? 'bg-green-500' : 'bg-red-500'
-                        }`} />
-                        <div>
-                          <p className="text-sm font-medium text-gray-900">{transaction.description}</p>
-                          <p className="text-xs text-gray-500">{transaction.date}</p>
-                        </div>
-                      </div>
-                      <div className="text-right">
-                        <p className={`text-sm font-semibold ${
-                          transaction.type === 'credit' ? 'text-green-600' : 'text-red-600'
-                        }`}>
-                          {transaction.type === 'credit' ? '+' : '-'}{formatCurrency(transaction.amount)}
-                        </p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Upcoming Invoices */}
-              <div className="bg-white rounded-lg shadow p-6">
-                <div className="flex justify-between items-center mb-4">
-                  <h3 className="text-lg font-semibold text-gray-900">Upcoming Invoices</h3>
-                  <button className="text-blue-600 hover:text-blue-800 text-sm font-medium">View All</button>
-                </div>
-                <div className="space-y-3">
-                  {upcomingInvoices.map((invoice) => (
-                    <div key={invoice.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                      <div>
-                        <p className="text-sm font-medium text-gray-900">{invoice.customer}</p>
-                        <p className="text-xs text-gray-500">Due: {invoice.dueDate}</p>
-                      </div>
-                      <div className="text-right">
-                        <p className="text-sm font-semibold text-gray-900">{formatCurrency(invoice.amount)}</p>
-                        <span className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getStatusColor(invoice.status)}`}>
-                          {invoice.status}
-                        </span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {/* Quick Actions */}
-            <div className="bg-white rounded-lg shadow p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h3>
-              <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                <button className="flex flex-col items-center p-4 border-2 border-dashed border-gray-300 rounded-lg hover:border-blue-400 hover:bg-blue-50 transition-colors">
-                  <Plus className="w-8 h-8 text-gray-400 mb-2" />
-                  <span className="text-sm font-medium text-gray-600">New Account</span>
-                </button>
-                <button className="flex flex-col items-center p-4 border-2 border-dashed border-gray-300 rounded-lg hover:border-blue-400 hover:bg-blue-50 transition-colors">
-                  <TrendingUp className="w-8 h-8 text-gray-400 mb-2" />
-                  <span className="text-sm font-medium text-gray-600">New Transaction</span>
-                </button>
-                <button className="flex flex-col items-center p-4 border-2 border-dashed border-gray-300 rounded-lg hover:border-blue-400 hover:bg-blue-50 transition-colors">
-                  <FileText className="w-8 h-8 text-gray-400 mb-2" />
-                  <span className="text-sm font-medium text-gray-600">Create Invoice</span>
-                </button>
-                <button className="flex flex-col items-center p-4 border-2 border-dashed border-gray-300 rounded-lg hover:border-blue-400 hover:bg-blue-50 transition-colors">
-                  <BarChart3 className="w-8 h-8 text-gray-400 mb-2" />
-                  <span className="text-sm font-medium text-gray-600">Generate Report</span>
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {activeTab === 'accounts' && (
-          <div className="bg-white rounded-lg shadow p-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Chart of Accounts</h2>
-            <p className="text-gray-600">Chart of accounts management coming soon...</p>
-          </div>
-        )}
-
-        {activeTab === 'transactions' && (
-          <div className="bg-white rounded-lg shadow p-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Transactions</h2>
-            <p className="text-gray-600">Transaction management coming soon...</p>
-          </div>
-        )}
-
-        {activeTab === 'invoices' && (
-          <div className="bg-white rounded-lg shadow p-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Invoices</h2>
-            <p className="text-gray-600">Invoice management coming soon...</p>
-          </div>
-        )}
-
-        {activeTab === 'reports' && (
-          <div className="bg-white rounded-lg shadow p-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Financial Reports</h2>
-            <p className="text-gray-600">Financial reporting coming soon...</p>
-          </div>
-        )}
-      </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/HR.tsx
+++ b/frontend/src/pages/HR.tsx
@@ -4,7 +4,7 @@ import { Plus } from 'lucide-react'
 import toast from 'react-hot-toast'
 
 const HR: React.FC = () => {
-  const [tab, setTab] = useState<'employees'|'attendance'>('employees')
+  const [tab, setTab] = useState<'employees'|'attendance'|'payrolls'|'leaves'>('employees')
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="bg-white shadow-sm border-b">
@@ -16,7 +16,7 @@ const HR: React.FC = () => {
       <div className="bg-white border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <nav className="flex space-x-8">
-            {['employees','attendance'].map(id => (
+            {['employees','attendance','payrolls','leaves'].map(id => (
               <button key={id} onClick={()=>setTab(id as any)}
                 className={`py-4 px-1 border-b-2 font-medium text-sm ${tab===id?'border-blue-500 text-blue-600':'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}
               >{id[0].toUpperCase()+id.slice(1)}</button>
@@ -27,6 +27,8 @@ const HR: React.FC = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
         {tab==='employees' && <EmployeesSection />}
         {tab==='attendance' && <AttendanceSection />}
+        {tab==='payrolls' && <PayrollSection />}
+        {tab==='leaves' && <LeaveSection />}
       </div>
     </div>
   )
@@ -86,6 +88,88 @@ function AttendanceSection(){
           <tbody>
             {items.map((r:any)=> (
               <tr key={r.id} className="border-t"><td className="px-3 py-2">{r.employee_id}</td><td className="px-3 py-2">{new Date(r.date).toLocaleString()}</td><td className="px-3 py-2">{r.check_in? new Date(r.check_in).toLocaleTimeString() : '-'}</td><td className="px-3 py-2">{r.check_out? new Date(r.check_out).toLocaleTimeString() : '-'}</td><td className="px-3 py-2">{r.notes}</td></tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function PayrollSection(){
+  const [items, setItems] = useState<any[]>([])
+  const [form, setForm] = useState({ employee_id: 0, base_salary: 0, allowances: 0, deductions: 0, period_start:'', period_end:'' })
+  const load = async()=>{ try { const r = await hrService.getPayrolls({ limit: 20 }); setItems(r.records||[]) } catch(e:any){ toast.error('Load failed') } }
+  useEffect(()=>{ load() }, [])
+  const create = async()=>{
+    try {
+      const payload = { ...form, net_pay: form.base_salary + form.allowances - form.deductions }
+      await hrService.createPayroll(payload as any)
+      setForm({ employee_id:0, base_salary:0, allowances:0, deductions:0, period_start:'', period_end:'' })
+      toast.success('Added')
+      load()
+    } catch(e:any){ toast.error('Create failed') }
+  }
+  return (
+    <div className="bg-white rounded-lg shadow p-6">
+      <div className="flex justify-between mb-4">
+        <div />
+        <div className="flex gap-2">
+          <input className="input" type="number" placeholder="Emp ID" value={form.employee_id||''} onChange={e=>setForm({...form,employee_id:Number(e.target.value)})} />
+          <input className="input" type="date" value={form.period_start} onChange={e=>setForm({...form,period_start:e.target.value})} />
+          <input className="input" type="date" value={form.period_end} onChange={e=>setForm({...form,period_end:e.target.value})} />
+          <input className="input" type="number" placeholder="Salary" value={form.base_salary||''} onChange={e=>setForm({...form,base_salary:Number(e.target.value)})} />
+          <input className="input" type="number" placeholder="Allow" value={form.allowances||''} onChange={e=>setForm({...form,allowances:Number(e.target.value)})} />
+          <input className="input" type="number" placeholder="Deduct" value={form.deductions||''} onChange={e=>setForm({...form,deductions:Number(e.target.value)})} />
+          <button className="btn-primary" onClick={create}><Plus className="w-4 h-4 mr-2" /> Add</button>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50"><tr><th className="px-3 py-2 text-left">Emp</th><th className="px-3 py-2 text-left">Period</th><th className="px-3 py-2 text-left">Net Pay</th><th className="px-3 py-2 text-left">Status</th></tr></thead>
+          <tbody>
+            {items.map((p:any)=>(
+              <tr key={p.id} className="border-t"><td className="px-3 py-2">{p.employee_id}</td><td className="px-3 py-2">{p.period_start} - {p.period_end}</td><td className="px-3 py-2">{p.net_pay}</td><td className="px-3 py-2">{p.status}</td></tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function LeaveSection(){
+  const [items, setItems] = useState<any[]>([])
+  const [form, setForm] = useState({ employee_id:0, start_date:'', end_date:'', type:'sick', reason:'' })
+  const load = async()=>{ try { const r = await hrService.getLeaves({ limit:20 }); setItems(r.records||[]) } catch(e:any){ toast.error('Load failed') } }
+  useEffect(()=>{ load() }, [])
+  const create = async()=>{
+    try {
+      await hrService.createLeave(form as any)
+      setForm({ employee_id:0, start_date:'', end_date:'', type:'sick', reason:'' })
+      toast.success('Added')
+      load()
+    } catch(e:any){ toast.error('Create failed') }
+  }
+  return (
+    <div className="bg-white rounded-lg shadow p-6">
+      <div className="flex justify-between mb-4">
+        <div />
+        <div className="flex gap-2">
+          <input className="input" type="number" placeholder="Emp ID" value={form.employee_id||''} onChange={e=>setForm({...form,employee_id:Number(e.target.value)})} />
+          <input className="input" type="date" value={form.start_date} onChange={e=>setForm({...form,start_date:e.target.value})} />
+          <input className="input" type="date" value={form.end_date} onChange={e=>setForm({...form,end_date:e.target.value})} />
+          <input className="input" placeholder="Type" value={form.type} onChange={e=>setForm({...form,type:e.target.value})} />
+          <input className="input" placeholder="Reason" value={form.reason} onChange={e=>setForm({...form,reason:e.target.value})} />
+          <button className="btn-primary" onClick={create}><Plus className="w-4 h-4 mr-2" /> Add</button>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50"><tr><th className="px-3 py-2 text-left">Emp</th><th className="px-3 py-2 text-left">Dates</th><th className="px-3 py-2 text-left">Type</th><th className="px-3 py-2 text-left">Status</th></tr></thead>
+          <tbody>
+            {items.map((l:any)=>(
+              <tr key={l.id} className="border-t"><td className="px-3 py-2">{l.employee_id}</td><td className="px-3 py-2">{l.start_date} - {l.end_date}</td><td className="px-3 py-2">{l.type}</td><td className="px-3 py-2">{l.status}</td></tr>
             ))}
           </tbody>
         </table>

--- a/frontend/src/pages/Organizations.tsx
+++ b/frontend/src/pages/Organizations.tsx
@@ -1,18 +1,66 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { adminService, OrganizationPayload } from '../services/adminService'
 
 const Organizations: React.FC = () => {
+  const [organizations, setOrganizations] = useState<any[]>([])
+  const [form, setForm] = useState<OrganizationPayload>({ name: '' })
+
+  const load = async () => {
+    const data = await adminService.getOrganizations()
+    setOrganizations(data)
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await adminService.createOrganization(form)
+    setForm({ name: '' })
+    load()
+  }
+
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Organizations</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          Manage organization settings and multi-tenancy.
-        </p>
+        <p className="mt-1 text-sm text-gray-500">Manage organization settings and multi-tenancy.</p>
       </div>
-      
+
       <div className="card">
         <div className="card-body">
-          <p className="text-gray-500">Organizations management page - Coming Soon</p>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input className="input" name="name" placeholder="Name" value={form.name} onChange={handleChange} required />
+            <button type="submit" className="btn-primary">Create Organization</button>
+          </form>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-body overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-4 py-2 text-left text-sm font-medium text-gray-500">Name</th>
+                <th className="px-4 py-2 text-left text-sm font-medium text-gray-500">Slug</th>
+                <th className="px-4 py-2 text-left text-sm font-medium text-gray-500">Users</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {organizations.map((org) => (
+                <tr key={org.id}>
+                  <td className="px-4 py-2 text-sm text-gray-900">{org.name}</td>
+                  <td className="px-4 py-2 text-sm text-gray-900">{org.slug}</td>
+                  <td className="px-4 py-2 text-sm text-gray-900">{org.user_count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -1,18 +1,100 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { adminService, UserPayload } from '../services/adminService'
 
 const Users: React.FC = () => {
+  const [users, setUsers] = useState<any[]>([])
+  const [roles, setRoles] = useState<any[]>([])
+  const [organizations, setOrganizations] = useState<any[]>([])
+  const [form, setForm] = useState<UserPayload>({
+    username: '',
+    email: '',
+    first_name: '',
+    last_name: '',
+    password: '',
+    organization_id: 1,
+    role_id: 1,
+  })
+
+  useEffect(() => {
+    const load = async () => {
+      const [u, r, o] = await Promise.all([
+        adminService.getUsers(),
+        adminService.getRoles(),
+        adminService.getOrganizations(),
+      ])
+      setUsers(u)
+      setRoles(r)
+      setOrganizations(o)
+    }
+    load()
+  }, [])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await adminService.createUser({
+      ...form,
+      organization_id: Number(form.organization_id),
+      role_id: Number(form.role_id),
+    })
+    setForm({ username: '', email: '', first_name: '', last_name: '', password: '', organization_id: 1, role_id: 1 })
+    const updated = await adminService.getUsers()
+    setUsers(updated)
+  }
+
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Users</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          Manage user accounts and permissions.
-        </p>
+        <p className="mt-1 text-sm text-gray-500">Manage user accounts and permissions.</p>
       </div>
-      
+
       <div className="card">
         <div className="card-body">
-          <p className="text-gray-500">Users management page - Coming Soon</p>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <input className="input" name="username" placeholder="Username" value={form.username} onChange={handleChange} required />
+              <input className="input" name="email" placeholder="Email" value={form.email} onChange={handleChange} required />
+              <input className="input" name="first_name" placeholder="First Name" value={form.first_name} onChange={handleChange} required />
+              <input className="input" name="last_name" placeholder="Last Name" value={form.last_name} onChange={handleChange} required />
+              <input className="input" type="password" name="password" placeholder="Password" value={form.password} onChange={handleChange} required />
+              <select className="input" name="organization_id" value={form.organization_id} onChange={handleChange}>
+                {organizations.map((o) => (
+                  <option key={o.id} value={o.id}>{o.name}</option>
+                ))}
+              </select>
+              <select className="input" name="role_id" value={form.role_id} onChange={handleChange}>
+                {roles.map((r) => (
+                  <option key={r.id} value={r.id}>{r.name}</option>
+                ))}
+              </select>
+            </div>
+            <button type="submit" className="btn-primary">Create User</button>
+          </form>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-body overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-4 py-2 text-left text-sm font-medium text-gray-500">Username</th>
+                <th className="px-4 py-2 text-left text-sm font-medium text-gray-500">Email</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {users.map((user) => (
+                <tr key={user.id}>
+                  <td className="px-4 py-2 text-sm text-gray-900">{user.username}</td>
+                  <td className="px-4 py-2 text-sm text-gray-900">{user.email}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -1,0 +1,45 @@
+import { api } from './authService'
+
+export interface UserPayload {
+  username: string
+  email: string
+  first_name: string
+  last_name: string
+  password: string
+  organization_id: number
+  role_id: number
+}
+
+export interface OrganizationPayload {
+  name: string
+  email?: string
+}
+
+class AdminService {
+  async getUsers() {
+    const response = await api.get('/users')
+    return response.data
+  }
+
+  async createUser(data: UserPayload) {
+    const response = await api.post('/users', data)
+    return response.data
+  }
+
+  async getOrganizations() {
+    const response = await api.get('/organizations')
+    return response.data
+  }
+
+  async createOrganization(data: OrganizationPayload) {
+    const response = await api.post('/organizations', data)
+    return response.data
+  }
+
+  async getRoles() {
+    const response = await api.get('/roles')
+    return response.data
+  }
+}
+
+export const adminService = new AdminService()

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -143,3 +143,4 @@ class AuthService {
 }
 
 export const authService = new AuthService()
+export { api }

--- a/frontend/src/services/crmService.ts
+++ b/frontend/src/services/crmService.ts
@@ -48,6 +48,10 @@ class CRMService {
     return data
   }
 
+  async deleteCustomer(id: number) {
+    await apiClient.delete(`/crm/customers/${id}`)
+  }
+
   async getLeads(params?: { skip?: number; limit?: number; q?: string }) {
     const { data } = await apiClient.get('/crm/leads', { params })
     return data
@@ -58,6 +62,10 @@ class CRMService {
     return data
   }
 
+  async deleteLead(id: number) {
+    await apiClient.delete(`/crm/leads/${id}`)
+  }
+
   async getOpportunities(params?: { skip?: number; limit?: number; q?: string }) {
     const { data } = await apiClient.get('/crm/opportunities', { params })
     return data
@@ -65,6 +73,30 @@ class CRMService {
 
   async createOpportunity(payload: Partial<Opportunity>) {
     const { data } = await apiClient.post('/crm/opportunities', payload)
+    return data
+  }
+
+  async deleteOpportunity(id: number) {
+    await apiClient.delete(`/crm/opportunities/${id}`)
+  }
+
+  async getOpportunityPipeline() {
+    const { data } = await apiClient.get('/crm/opportunities/pipeline')
+    return data
+  }
+
+  async advanceOpportunity(id: number) {
+    const { data } = await apiClient.post(`/crm/opportunities/${id}/advance`)
+    return data
+  }
+
+  async getCommunications(params?: { skip?: number; limit?: number; customer_id?: number; lead_id?: number; opportunity_id?: number }) {
+    const { data } = await apiClient.get('/crm/communications', { params })
+    return data
+  }
+
+  async createCommunication(payload: any) {
+    const { data } = await apiClient.post('/crm/communications', payload)
     return data
   }
 }

--- a/frontend/src/services/hrService.ts
+++ b/frontend/src/services/hrService.ts
@@ -24,6 +24,32 @@ export interface Attendance {
   updated_at: string
 }
 
+export interface Payroll {
+  id: number
+  employee_id: number
+  period_start: string
+  period_end: string
+  base_salary: number
+  allowances: number
+  deductions: number
+  net_pay: number
+  status: string
+  created_at: string
+  updated_at: string
+}
+
+export interface Leave {
+  id: number
+  employee_id: number
+  start_date: string
+  end_date: string
+  type: string
+  status: string
+  reason?: string
+  created_at: string
+  updated_at: string
+}
+
 class HRService {
   async getEmployees(params?: { skip?: number; limit?: number; q?: string }) {
     const { data } = await apiClient.get('/hr/employees', { params })
@@ -42,6 +68,26 @@ class HRService {
 
   async createAttendance(payload: Partial<Attendance>) {
     const { data } = await apiClient.post('/hr/attendance', payload)
+    return data
+  }
+
+  async getPayrolls(params?: { employee_id?: number; skip?: number; limit?: number }) {
+    const { data } = await apiClient.get('/hr/payrolls', { params })
+    return data
+  }
+
+  async createPayroll(payload: Partial<Payroll>) {
+    const { data } = await apiClient.post('/hr/payrolls', payload)
+    return data
+  }
+
+  async getLeaves(params?: { employee_id?: number; skip?: number; limit?: number }) {
+    const { data } = await apiClient.get('/hr/leaves', { params })
+    return data
+  }
+
+  async createLeave(payload: Partial<Leave>) {
+    const { data } = await apiClient.post('/hr/leaves', payload)
     return data
   }
 }


### PR DESCRIPTION
## Summary
- add missing AccountCategory import and tuple typing
- implement payment listing service and API endpoint
- calculate cash flow summary from transactions

## Testing
- `pytest`
- `python -m py_compile app/services/finance_service.py app/api/v1/endpoints/finance.py`


------
https://chatgpt.com/codex/tasks/task_e_689ef964ef788328a89e778d1eb94df5